### PR TITLE
Add wind down suggestion component

### DIFF
--- a/src/components/WindDownSuggestion.tsx
+++ b/src/components/WindDownSuggestion.tsx
@@ -1,0 +1,74 @@
+import React, { useState, useEffect } from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { colors } from '../styles/theme';
+import defaultSuggestions from '../data/windDownSuggestions';
+
+interface WindDownSuggestionProps {
+  isDarkMode: boolean;
+  /**
+   * Optional custom suggestions list.
+   * When provided it replaces the defaults.
+   */
+  suggestions?: string[];
+}
+
+const WindDownSuggestion: React.FC<WindDownSuggestionProps> = ({
+  isDarkMode,
+  suggestions = defaultSuggestions,
+}) => {
+  const [index, setIndex] = useState(0);
+  const theme = isDarkMode ? colors.dark : colors.light;
+
+  useEffect(() => {
+    // Pick a random suggestion when mounted
+    const randomIndex = Math.floor(Math.random() * suggestions.length);
+    setIndex(randomIndex);
+  }, [suggestions]);
+
+  const next = () => {
+    setIndex(prev => (prev + 1) % suggestions.length);
+  };
+
+  return (
+    <View style={[styles.container, { backgroundColor: theme.card, borderColor: theme.border }]}>
+      <Text style={[styles.title, { color: theme.text }]}>Wind-down suggestion</Text>
+      <Text style={[styles.suggestion, { color: theme.primary }]}>{suggestions[index]}</Text>
+      {suggestions.length > 1 && (
+        <TouchableOpacity style={[styles.button, { backgroundColor: theme.accent }]} onPress={next}>
+          <Text style={styles.buttonText}>Another Tip</Text>
+        </TouchableOpacity>
+      )}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 12,
+    borderRadius: 8,
+    borderWidth: 1,
+    alignItems: 'center',
+    marginVertical: 8,
+  },
+  title: {
+    fontSize: 14,
+    fontWeight: '600',
+    marginBottom: 4,
+  },
+  suggestion: {
+    fontSize: 16,
+    textAlign: 'center',
+    marginBottom: 8,
+  },
+  button: {
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+    borderRadius: 6,
+  },
+  buttonText: {
+    color: '#FFFFFF',
+    fontWeight: '600',
+  },
+});
+
+export default WindDownSuggestion;

--- a/src/components/WindDownSuggestion.tsx
+++ b/src/components/WindDownSuggestion.tsx
@@ -34,7 +34,11 @@ const WindDownSuggestion: React.FC<WindDownSuggestionProps> = ({
       <Text style={[styles.title, { color: theme.text }]}>Wind-down suggestion</Text>
       <Text style={[styles.suggestion, { color: theme.primary }]}>{suggestions[index]}</Text>
       {suggestions.length > 1 && (
-        <TouchableOpacity style={[styles.button, { backgroundColor: theme.accent }]} onPress={next}>
+        <TouchableOpacity
+          style={[styles.button, { backgroundColor: theme.accent }]}
+          onPress={next}
+          accessibilityLabel="Next wind-down tip"
+        >
           <Text style={styles.buttonText}>Another Tip</Text>
         </TouchableOpacity>
       )}

--- a/src/data/windDownSuggestions.ts
+++ b/src/data/windDownSuggestions.ts
@@ -1,0 +1,11 @@
+export const defaultWindDownSuggestions: string[] = [
+  'Read a few pages of a book',
+  'Try a short meditation session',
+  'Listen to calming music',
+  'Write in a journal',
+  'Take a warm shower or bath',
+  'Stretch or do gentle yoga',
+  'Prepare your to-do list for tomorrow'
+];
+
+export default defaultWindDownSuggestions;

--- a/src/screens/SleepCalculatorScreen.tsx
+++ b/src/screens/SleepCalculatorScreen.tsx
@@ -18,6 +18,7 @@ import { SleepSettings, WindDownOption } from '../types';
 
 import TimePicker from '../components/TimePicker';
 import WindDownSelector from '../components/WindDownSelector';
+import WindDownSuggestion from '../components/WindDownSuggestion';
 import ResultCard from '../components/ResultCard';
 
 const SleepCalculatorScreen: React.FC = () => {
@@ -195,6 +196,8 @@ const SleepCalculatorScreen: React.FC = () => {
                         isDarkMode={isDarkMode}
                     />
                 </View>
+
+                <WindDownSuggestion isDarkMode={isDarkMode} />
 
                 <ResultCard
                     bedtime={bedtime}


### PR DESCRIPTION
## Summary
- list default wind-down suggestions
- show a WindDownSuggestion on the Sleep Calculator screen

## Testing
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_6850bd33f0a8832da485e99bd9ff0074