### PR TITLE
Add sleep review tracking

### DIFF
--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -15,13 +15,6 @@ import SettingsScreen from '../screens/SettingsScreen';
 // Tab navigator
 const Tab = createBottomTabNavigator<RootStackParamList>();
 
-// Define mapping of route names to icons (outside of component)
-const routeIcons: Record<string, { active: string; inactive: string }> = {
-  Home: { active: 'home', inactive: 'home-outline' },
-  SleepCalculator: { active: 'calculator', inactive: 'calculator-outline' },
-  History: { active: 'time', inactive: 'time-outline' },
-  Settings: { active: 'settings', inactive: 'settings-outline' },
-};
 
 interface NavigationProps {
   isDarkMode: boolean;

--- a/src/screens/HistoryScreen.tsx
+++ b/src/screens/HistoryScreen.tsx
@@ -17,6 +17,7 @@ import { deleteHistoryEntry, loadAppSettings, loadSleepHistory } from '../utils/
 import { SleepHistoryEntry } from '../types';
 import { colors, getGlobalStyles } from '../styles/theme';
 import { formatTime } from '../utils/sleepCalculator';
+import SleepReviewScreen from './SleepReviewScreen';
 
 const HistoryScreen: React.FC = () => {
   const colorScheme = useColorScheme();
@@ -24,6 +25,7 @@ const HistoryScreen: React.FC = () => {
   const [history, setHistory] = useState<SleepHistoryEntry[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
+  const [reviewEntry, setReviewEntry] = useState<SleepHistoryEntry | null>(null);
   
   // Use app settings for dark mode if available, otherwise use system
   const isDarkMode = appSettings?.theme === 'system'
@@ -106,6 +108,15 @@ const HistoryScreen: React.FC = () => {
   const handleDelete = async (id: string) => {
     await deleteHistoryEntry(id);
     fetchHistory(); // Refresh the list
+  };
+
+  const openReview = (entry: SleepHistoryEntry) => {
+    setReviewEntry(entry);
+  };
+
+  const closeReview = () => {
+    setReviewEntry(null);
+    fetchHistory();
   };
 
   // Get appropriate text for when the entry was created
@@ -202,17 +213,38 @@ const HistoryScreen: React.FC = () => {
                 <Text style={styles.text}>{entry.windDownPeriod} min</Text>
               </View>
             </View>
-            
-            <TouchableOpacity 
-              style={localStyles.deleteButton}
-              onPress={() => confirmDelete(entry)}
-            >
-              <Ionicons name="trash-outline" size={20} color={theme.danger} />
-              <Text style={localStyles.deleteText}>Delete</Text>
-            </TouchableOpacity>
+
+            <View style={localStyles.reviewRow}>
+              <Text style={styles.text}>Quality: {entry.quality ?? '-'}</Text>
+              <Text style={styles.text}>Technique: {entry.technique || '-'}</Text>
+            </View>
+
+            <View style={localStyles.actionsRow}>
+              <TouchableOpacity
+                style={localStyles.editButton}
+                onPress={() => openReview(entry)}
+              >
+                <Ionicons name="pencil" size={20} color={theme.primary} />
+                <Text style={localStyles.editText}>Edit</Text>
+              </TouchableOpacity>
+
+              <TouchableOpacity
+                style={localStyles.deleteButton}
+                onPress={() => confirmDelete(entry)}
+              >
+                <Ionicons name="trash-outline" size={20} color={theme.danger} />
+                <Text style={localStyles.deleteText}>Delete</Text>
+              </TouchableOpacity>
+            </View>
           </View>
         ))}
       </ScrollView>
+      <SleepReviewScreen
+        visible={reviewEntry !== null}
+        entry={reviewEntry}
+        onClose={closeReview}
+        isDarkMode={isDarkMode}
+      />
     </SafeAreaView>
   );
 };
@@ -252,6 +284,24 @@ const localStyles = StyleSheet.create({
     alignItems: 'center',
     alignSelf: 'flex-end',
     padding: 8,
+  },
+  editButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: 8,
+  },
+  actionsRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  editText: {
+    marginLeft: 4,
+    color: '#3949AB',
+  },
+  reviewRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 8,
   },
   emptyState: {
     alignItems: 'center',

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -15,13 +15,14 @@ import { loadAppSettings, loadSleepHistory, loadSleepSettings } from '../utils/s
 import { calculateSleepTimes } from '../utils/sleepCalculator';
 import { colors, getGlobalStyles } from '../styles/theme';
 import { SleepHistoryEntry, SleepSettings } from '../types';
+import SleepReviewScreen from './SleepReviewScreen';
 
 const HomeScreen: React.FC = () => {
   const navigation = useNavigation();
   const colorScheme = useColorScheme();
   const [appSettings, setAppSettings] = useState<any>(null);
   const [lastSettings, setLastSettings] = useState<SleepSettings | null>(null);
-  const [recentHistory, setRecentHistory] = useState<SleepHistoryEntry[]>([]);
+  const [pendingReview, setPendingReview] = useState<SleepHistoryEntry | null>(null);
   
   // Use app settings for dark mode if available, otherwise use system
   const isDarkMode = appSettings?.theme === 'system'
@@ -42,7 +43,10 @@ const HomeScreen: React.FC = () => {
 
       const history = await loadSleepHistory();
       if (history && history.length > 0) {
-        setRecentHistory(history.slice(0, 3)); // Get most recent 3 entries
+        const latest = history[0];
+        if (!latest.quality && new Date() > latest.wakeUpTime) {
+          setPendingReview(latest);
+        }
       }
     };
 
@@ -170,6 +174,12 @@ const HomeScreen: React.FC = () => {
           </TouchableOpacity>
         </View>
       </ScrollView>
+      <SleepReviewScreen
+        visible={pendingReview !== null}
+        entry={pendingReview}
+        onClose={() => setPendingReview(null)}
+        isDarkMode={isDarkMode}
+      />
     </SafeAreaView>
   );
 };

--- a/src/screens/SleepReviewScreen.tsx
+++ b/src/screens/SleepReviewScreen.tsx
@@ -1,0 +1,84 @@
+import React, { useState } from 'react';
+import { Modal, View, Text, StyleSheet, TextInput, TouchableOpacity } from 'react-native';
+import Slider from '@react-native-community/slider';
+import { SleepHistoryEntry } from '../types';
+import { updateHistoryEntry } from '../utils/storage';
+import { colors, getGlobalStyles } from '../styles/theme';
+
+interface Props {
+  visible: boolean;
+  entry: SleepHistoryEntry | null;
+  onClose: () => void;
+  isDarkMode: boolean;
+}
+
+const SleepReviewScreen: React.FC<Props> = ({ visible, entry, onClose, isDarkMode }) => {
+  const theme = isDarkMode ? colors.dark : colors.light;
+  const styles = getGlobalStyles(isDarkMode);
+  const [quality, setQuality] = useState<number>(entry?.quality ?? 3);
+  const [technique, setTechnique] = useState(entry?.technique ?? '');
+  if (!entry) return null;
+
+  const handleSave = async () => {
+    await updateHistoryEntry(entry.id, { quality, technique });
+    onClose();
+  };
+
+  return (
+    <Modal visible={visible} transparent animationType="slide">
+      <View style={local.overlay}>
+        <View style={[styles.card, local.container]}>
+          <Text style={styles.header}>Review Your Sleep</Text>
+          <Text style={[styles.text, local.label]}>Quality: {quality}</Text>
+          <Slider
+            minimumValue={1}
+            maximumValue={5}
+            step={1}
+            value={quality}
+            onValueChange={setQuality}
+            minimumTrackTintColor={theme.primary}
+            maximumTrackTintColor={theme.border}
+            thumbTintColor={theme.primary}
+          />
+          <TextInput
+            placeholder="Technique used (optional)"
+            placeholderTextColor={theme.subText}
+            value={technique}
+            onChangeText={setTechnique}
+            style={[styles.text, local.input, { borderColor: theme.border, color: theme.text }]}
+          />
+          <TouchableOpacity style={styles.buttonWithMargin} onPress={handleSave}>
+            <Text style={styles.buttonText}>Save</Text>
+          </TouchableOpacity>
+          <TouchableOpacity onPress={onClose}>
+            <Text style={[styles.caption, { color: theme.danger }]}>Cancel</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </Modal>
+  );
+};
+
+const local = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  container: {
+    width: '90%',
+  },
+  input: {
+    borderWidth: 1,
+    borderRadius: 8,
+    padding: 8,
+    marginTop: 16,
+  },
+  label: {
+    marginTop: 8,
+    marginBottom: 8,
+  },
+});
+
+export default SleepReviewScreen;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,6 +10,10 @@ export interface SleepHistoryEntry extends SleepSettings {
   id: string;
   createdAt: Date;
   title?: string;
+  /** Rating from 1 (poor) to 5 (great) */
+  quality?: number;
+  /** Meditation or wind-down technique used */
+  technique?: string;
 }
 
 export type ThemeMode = 'light' | 'dark';

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -79,6 +79,7 @@ export const loadThemeMode = async (): Promise<ThemeMode | null> => {
  */
 export const saveSleepHistoryEntry = async (
     settings: SleepSettings,
+    extras?: { quality?: number; technique?: string },
 ): Promise<void> => {
     try {
         // Get existing history
@@ -89,6 +90,8 @@ export const saveSleepHistoryEntry = async (
             ...settings,
             id: Date.now().toString(),
             createdAt: new Date(),
+            quality: extras?.quality,
+            technique: extras?.technique,
         };
 
         // Add to history
@@ -122,6 +125,8 @@ export const loadSleepHistory = async (): Promise<
                 ...entry,
                 wakeUpTime: new Date(entry.wakeUpTime),
                 createdAt: new Date(entry.createdAt),
+                quality: entry.quality,
+                technique: entry.technique,
             }));
         }
         return [];


### PR DESCRIPTION
## Summary
- track sleep quality and wind-down technique in `SleepHistoryEntry`
- store these fields when saving history
- provide `SleepReviewScreen` modal for rating and technique entry
- show and edit review data in History
- prompt for review on Home after wake-up
- remove unused navigation constant

## Testing
- `npm run lint`
- `npx jest` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_6850bd3550b0832dbfffaef171933037