### PR TITLE
Add wind-down notification and lockdown features

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -13,6 +13,7 @@ import { useColorScheme } from 'react-native';
 import { loadAppSettings } from './src/utils/storage';
 import AppNavigator from './src/navigation/AppNavigator';
 import { registerIcons } from './src/utils/iconSetup';
+import { initNotifications } from './src/utils/notifications';
 
 function App() {
   const colorScheme = useColorScheme();
@@ -21,6 +22,7 @@ function App() {
   useEffect(() => {
     // Initialize icons
     registerIcons();
+    initNotifications();
     
     // Load saved theme preference
     const loadTheme = async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "react": "19.1.0",
         "react-native": "0.80.0",
         "react-native-gesture-handler": "^2.26.0",
+        "react-native-push-notification": "^8.1.1",
         "react-native-reanimated": "^3.18.0",
         "react-native-safe-area-context": "^5.4.1",
         "react-native-screens": "^4.11.1",
@@ -3022,6 +3023,20 @@
         "react-native-windows": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@react-native-community/push-notification-ios": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/push-notification-ios/-/push-notification-ios-1.11.0.tgz",
+      "integrity": "sha512-nfkUs8P2FeydOCR4r7BNmtGxAxI22YuGP6RmqWt6c8EEMUpqvIhNKWkRSFF3pHjkgJk2tpRb9wQhbezsqTyBvA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.3",
+        "react-native": ">=0.58.4"
       }
     },
     "node_modules/@react-native-community/slider": {
@@ -10898,6 +10913,16 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-push-notification": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/react-native-push-notification/-/react-native-push-notification-8.1.1.tgz",
+      "integrity": "sha512-XpBtG/w+a6WXTxu6l1dNYyTiHnbgnvjoc3KxPTxYkaIABRmvuJZkFxqruyGvfCw7ELAlZEAJO+dthdTabCe1XA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@react-native-community/push-notification-ios": "^1.10.1",
+        "react-native": ">=0.33"
       }
     },
     "node_modules/react-native-reanimated": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react": "19.1.0",
     "react-native": "0.80.0",
     "react-native-gesture-handler": "^2.26.0",
+    "react-native-push-notification": "^8.1.1",
     "react-native-reanimated": "^3.18.0",
     "react-native-safe-area-context": "^5.4.1",
     "react-native-screens": "^4.11.1",

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { navigationRef } from './RootNavigation';
 import Ionicons from 'react-native-vector-icons/Ionicons';
 
 import { RootStackParamList } from '../types';
@@ -9,6 +10,7 @@ import HomeScreen from '../screens/HomeScreen';
 import SleepCalculatorScreen from '../screens/SleepCalculatorScreen';
 import HistoryScreen from '../screens/HistoryScreen';
 import SettingsScreen from '../screens/SettingsScreen';
+import WindDownScreen from '../screens/WindDownScreen';
 
 const Tab = createBottomTabNavigator<RootStackParamList>();
 
@@ -54,7 +56,7 @@ const AppNavigator: React.FC<NavigationProps> = ({ isDarkMode }) => {
   const theme = isDarkMode ? colors.dark : colors.light;
 
   return (
-    <NavigationContainer>
+    <NavigationContainer ref={navigationRef}>
       <Tab.Navigator
         screenOptions={({ route }) => ({
           headerShown: true,
@@ -90,6 +92,14 @@ const AppNavigator: React.FC<NavigationProps> = ({ isDarkMode }) => {
           name="Settings"
           component={SettingsScreen}
           options={{ title: 'Settings' }}
+        />
+        <Tab.Screen
+          name="WindDown"
+          component={WindDownScreen}
+          options={{
+            title: 'Wind Down',
+            tabBarButton: () => null,
+          }}
         />
       </Tab.Navigator>
     </NavigationContainer>

--- a/src/navigation/RootNavigation.ts
+++ b/src/navigation/RootNavigation.ts
@@ -1,0 +1,10 @@
+import { createNavigationContainerRef } from '@react-navigation/native';
+import { RootStackParamList } from '../types';
+
+export const navigationRef = createNavigationContainerRef<RootStackParamList>();
+
+export function navigate(name: keyof RootStackParamList, params?: any) {
+  if (navigationRef.isReady()) {
+    navigationRef.navigate(name as never, params as never);
+  }
+}

--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -15,13 +15,6 @@ import SettingsScreen from '../screens/SettingsScreen';
 // Tab navigator
 const Tab = createBottomTabNavigator<RootStackParamList>();
 
-// Define mapping of route names to icons (outside of component)
-const routeIcons: Record<string, { active: string; inactive: string }> = {
-  Home: { active: 'home', inactive: 'home-outline' },
-  SleepCalculator: { active: 'calculator', inactive: 'calculator-outline' },
-  History: { active: 'time', inactive: 'time-outline' },
-  Settings: { active: 'settings', inactive: 'settings-outline' },
-};
 
 interface NavigationProps {
   isDarkMode: boolean;

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -14,14 +14,13 @@ import Ionicons from '@react-native-vector-icons/ionicons';
 import { loadAppSettings, loadSleepHistory, loadSleepSettings } from '../utils/storage';
 import { calculateSleepTimes } from '../utils/sleepCalculator';
 import { colors, getGlobalStyles } from '../styles/theme';
-import { SleepHistoryEntry, SleepSettings } from '../types';
+import { SleepSettings } from '../types';
 
 const HomeScreen: React.FC = () => {
   const navigation = useNavigation();
   const colorScheme = useColorScheme();
   const [appSettings, setAppSettings] = useState<any>(null);
   const [lastSettings, setLastSettings] = useState<SleepSettings | null>(null);
-  const [recentHistory, setRecentHistory] = useState<SleepHistoryEntry[]>([]);
   
   // Use app settings for dark mode if available, otherwise use system
   const isDarkMode = appSettings?.theme === 'system'

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -15,6 +15,8 @@ import { AppSettings, WindDownOption } from '../types';
 import { colors, getGlobalStyles } from '../styles/theme';
 import { loadAppSettings, saveAppSettings } from '../utils/storage';
 import WindDownSelector from '../components/WindDownSelector';
+import TimePicker from '../components/TimePicker';
+import { scheduleDailyWindDownReminder } from '../utils/notifications';
 
 const SettingsScreen: React.FC = () => {
   const deviceColorScheme = useColorScheme();
@@ -24,6 +26,8 @@ const SettingsScreen: React.FC = () => {
     optimizeSleepCycles: false,
     defaultSleepDuration: 8,
     defaultWindDownPeriod: 30,
+    lockdownMode: false,
+    windDownReminderTime: null,
   });
 
   // Use app settings for dark mode if available, otherwise use system
@@ -40,6 +44,9 @@ const SettingsScreen: React.FC = () => {
       const savedSettings = await loadAppSettings();
       if (savedSettings) {
         setSettings(savedSettings);
+        if (savedSettings.windDownReminderTime) {
+          scheduleDailyWindDownReminder(savedSettings.windDownReminderTime);
+        }
       }
     };
 
@@ -51,6 +58,9 @@ const SettingsScreen: React.FC = () => {
     const newSettings = { ...settings, ...updates };
     setSettings(newSettings);
     saveAppSettings(newSettings);
+    if (updates.windDownReminderTime) {
+      scheduleDailyWindDownReminder(updates.windDownReminderTime);
+    }
   };
 
   // Format sleep duration display
@@ -63,6 +73,19 @@ const SettingsScreen: React.FC = () => {
     } else {
       return `${wholeHours} hours ${minutes} min`;
     }
+  };
+
+  const parseTime = (timeStr: string): Date => {
+    const [h, m] = timeStr.split(':').map(Number);
+    const d = new Date();
+    d.setHours(h, m, 0, 0);
+    return d;
+  };
+
+  const toTimeString = (date: Date): string => {
+    const h = String(date.getHours()).padStart(2, '0');
+    const m = String(date.getMinutes()).padStart(2, '0');
+    return `${h}:${m}`;
   };
 
   // Wind-down period options
@@ -179,16 +202,42 @@ const SettingsScreen: React.FC = () => {
             />
           </View>
 
-          <View style={{ marginTop: 20 }}>
-            <Text style={styles.text}>Default Wind-down Period</Text>
-            <WindDownSelector
-              options={windDownOptions}
-              selectedOption={settings.defaultWindDownPeriod}
-              onSelect={(value) => updateSettings({ defaultWindDownPeriod: value })}
-              isDarkMode={isDarkMode}
-            />
-          </View>
+        <View style={{ marginTop: 20 }}>
+          <Text style={styles.text}>Default Wind-down Period</Text>
+          <WindDownSelector
+            options={windDownOptions}
+            selectedOption={settings.defaultWindDownPeriod}
+            onSelect={(value) => updateSettings({ defaultWindDownPeriod: value })}
+            isDarkMode={isDarkMode}
+          />
         </View>
+      </View>
+
+      {/* Notifications */}
+      <View style={styles.card}>
+        <Text style={styles.subHeader}>Wind-down Notifications</Text>
+
+        <View style={localStyles.settingRow}>
+          <Text style={styles.text}>Lockdown Mode</Text>
+          <Switch
+            value={settings.lockdownMode}
+            onValueChange={(value) => updateSettings({ lockdownMode: value })}
+            trackColor={{ false: theme.border, true: theme.primary }}
+            thumbColor={theme.card}
+          />
+        </View>
+
+        <TimePicker
+          label="Reminder Time"
+          value={parseTime(settings.windDownReminderTime || '21:00')}
+          onChange={(date) =>
+            updateSettings({ windDownReminderTime: toTimeString(date) })
+          }
+          isDarkMode={isDarkMode}
+          use24HourFormat={true}
+        />
+        <Text style={[styles.caption, { marginTop: 4 }]}>Daily reminder to start winding down</Text>
+      </View>
 
         {/* About */}
         <View style={styles.card}>

--- a/src/screens/SleepCalculatorScreen.tsx
+++ b/src/screens/SleepCalculatorScreen.tsx
@@ -13,6 +13,8 @@ import Slider from '@react-native-community/slider';
 
 import { calculateSleepTimes } from '../utils/sleepCalculator';
 import { loadSleepSettings, saveSleepSettings, saveAppSettings, loadAppSettings, saveSleepHistoryEntry } from '../utils/storage';
+import { scheduleWindDownNotification } from '../utils/notifications';
+import { setAppBlocking } from '../utils/screenTime';
 import { getGlobalStyles, colors } from '../styles/theme';
 import { SleepSettings, WindDownOption } from '../types';
 
@@ -120,6 +122,12 @@ const SleepCalculatorScreen: React.FC = () => {
         };
 
         await saveSleepHistoryEntry(settings);
+
+        scheduleWindDownNotification(windDownTime);
+
+        if (appSettings?.lockdownMode) {
+            setAppBlocking([], windDownTime, bedtime);
+        }
 
         // Show confirmation and offer to view history
         Alert.alert(

--- a/src/screens/WindDownScreen.tsx
+++ b/src/screens/WindDownScreen.tsx
@@ -1,0 +1,58 @@
+import React, { useEffect, useState } from 'react';
+import { SafeAreaView, ScrollView, Text, useColorScheme } from 'react-native';
+import { calculateSleepTimes } from '../utils/sleepCalculator';
+import { loadAppSettings, loadSleepSettings } from '../utils/storage';
+import { getGlobalStyles } from '../styles/theme';
+import ResultCard from '../components/ResultCard';
+
+const WindDownScreen: React.FC = () => {
+  const scheme = useColorScheme();
+  const [appSettings, setAppSettings] = useState<any>(null);
+  const [bedtime, setBedtime] = useState<Date | null>(null);
+  const [windDownTime, setWindDownTime] = useState<Date | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      const a = await loadAppSettings();
+      const s = await loadSleepSettings();
+      setAppSettings(a);
+      if (s) {
+        const times = calculateSleepTimes(
+          s.wakeUpTime,
+          s.sleepDuration,
+          s.windDownPeriod,
+        );
+        setBedtime(times.bedtime);
+        setWindDownTime(times.windDownTime);
+      }
+    };
+    load();
+  }, []);
+
+  const isDarkMode = appSettings?.theme === 'system'
+    ? scheme === 'dark'
+    : appSettings?.theme === 'dark';
+  const styles = getGlobalStyles(isDarkMode);
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <ScrollView style={{ padding: 16 }}>
+        <Text style={styles.header}>Wind-down Tips</Text>
+        {bedtime && windDownTime && (
+          <ResultCard
+            bedtime={bedtime}
+            windDownTime={windDownTime}
+            isDarkMode={isDarkMode}
+            use24HourFormat={appSettings?.use24HourFormat}
+          />
+        )}
+        <Text style={[styles.subHeader, { marginTop: 12 }]}>Suggestions</Text>
+        <Text style={styles.text}>• Dim the lights and reduce screen use.</Text>
+        <Text style={styles.text}>• Try meditation or gentle stretching.</Text>
+        <Text style={styles.text}>• Prepare for tomorrow to clear your mind.</Text>
+      </ScrollView>
+    </SafeAreaView>
+  );
+};
+
+export default WindDownScreen;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -20,6 +20,7 @@ export type RootStackParamList = {
   SleepCalculator: undefined;
   History: undefined;
   Settings: undefined;
+  WindDown: undefined;
 };
 
 export interface AppSettings {
@@ -28,4 +29,6 @@ export interface AppSettings {
   optimizeSleepCycles: boolean;
   defaultSleepDuration: number;
   defaultWindDownPeriod: WindDownOption;
+  lockdownMode: boolean;
+  windDownReminderTime: string | null;
 }

--- a/src/utils/notifications.ts
+++ b/src/utils/notifications.ts
@@ -1,0 +1,47 @@
+import PushNotification, { Importance } from 'react-native-push-notification';
+import { Platform } from 'react-native';
+import { navigate } from '../navigation/RootNavigation';
+
+export const initNotifications = () => {
+  PushNotification.configure({
+    onNotification: notification => {
+      if (notification.userInteraction) {
+        navigate('WindDown');
+      }
+      // @ts-ignore
+      notification.finish && notification.finish();
+    },
+    requestPermissions: Platform.OS === 'ios',
+  });
+
+  if (Platform.OS === 'android') {
+    PushNotification.createChannel(
+      {
+        channelId: 'winddown',
+        channelName: 'Wind Down',
+        importance: Importance.DEFAULT,
+      },
+      () => {},
+    );
+  }
+};
+
+export const scheduleWindDownNotification = (date: Date) => {
+  PushNotification.localNotificationSchedule({
+    channelId: 'winddown',
+    message: 'Time to wind down for bed',
+    date,
+    allowWhileIdle: true,
+  });
+};
+
+export const scheduleDailyWindDownReminder = (timeString: string) => {
+  const [h, m] = timeString.split(':').map(Number);
+  const date = new Date();
+  date.setHours(h, m, 0, 0);
+  if (date < new Date()) {
+    date.setDate(date.getDate() + 1);
+  }
+  PushNotification.cancelAllLocalNotifications();
+  scheduleWindDownNotification(date);
+};

--- a/src/utils/notifications.ts
+++ b/src/utils/notifications.ts
@@ -42,6 +42,6 @@ export const scheduleDailyWindDownReminder = (timeString: string) => {
   if (date < new Date()) {
     date.setDate(date.getDate() + 1);
   }
-  PushNotification.cancelAllLocalNotifications();
+  PushNotification.cancelLocalNotifications({ channelId: 'winddown' });
   scheduleWindDownNotification(date);
 };

--- a/src/utils/screenTime.ts
+++ b/src/utils/screenTime.ts
@@ -1,0 +1,40 @@
+import { NativeModules } from 'react-native';
+
+const { ScreenTimeModule } = NativeModules;
+
+export interface UsageStats {
+  [packageName: string]: number;
+}
+
+export const isScreenTimeAvailable = (): boolean => {
+  return !!ScreenTimeModule;
+};
+
+export const getScreenTimeReport = async (): Promise<UsageStats | null> => {
+  if (!ScreenTimeModule || typeof ScreenTimeModule.getScreenTimeReport !== 'function') {
+    return null;
+  }
+  try {
+    return await ScreenTimeModule.getScreenTimeReport();
+  } catch (e) {
+    console.warn('Failed to get screen time report', e);
+    return null;
+  }
+};
+
+export const setAppBlocking = async (
+  packages: string[],
+  start: Date,
+  end: Date,
+): Promise<boolean> => {
+  if (!ScreenTimeModule || typeof ScreenTimeModule.setAppBlocking !== 'function') {
+    return false;
+  }
+  try {
+    await ScreenTimeModule.setAppBlocking(packages, start.getTime(), end.getTime());
+    return true;
+  } catch (e) {
+    console.warn('Failed to set app blocking', e);
+    return false;
+  }
+};

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -202,6 +202,8 @@ export const loadAppSettings = async (): Promise<AppSettings | null> => {
             optimizeSleepCycles: false,
             defaultSleepDuration: 8,
             defaultWindDownPeriod: 30,
+            lockdownMode: false,
+            windDownReminderTime: null,
         };
     } catch (error) {
         console.error('Error loading app settings:', error);


### PR DESCRIPTION
## Summary
- add modules for screen time and notifications
- add wind-down tips screen and connect via navigation
- store lockdown mode and reminder times in settings
- schedule local notifications and optional app blocking
- expose navigation ref for notification taps

## Testing
- `npm run lint`
- `npm test` *(fails: SyntaxError in react-native-gesture-handler)*

------
https://chatgpt.com/codex/tasks/task_e_6850bd360754832dba52467ab2817dc1